### PR TITLE
Automatically adding the user to the group video

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -82,6 +82,9 @@ RestartSec=5s
 WantedBy=multi-user.target
 EOF
 
+    echo "Adding the current user to the group video"
+    sudo addgroup ${USER} video
+
     echo "Enabling systemd service."
     sudo systemctl enable autodarts
 


### PR DESCRIPTION
Using Ubuntu 22.04 the user running autodarts needs to be in the group video to be able to access the cameras. Therefore I recommend to add mentioned lines. 

In case the group is not available or not needed this command usually does not harm the system BUT it grants rights which cannot be safely undone.

Please be aware that Ubuntu, Debian, Suse, Mandriva and others to have an operational packaging system which handles these things much saver than the install script here. Nevertheless it might help others to avoid mistakes.