### PR TITLE
fix(install): wrong command for adding user to group

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -155,7 +155,7 @@ EOF
   fi
 
   echo "Adding the current user to the group video"
-  sudo addgroup ${USER} video
+  sudo adduser ${USER} video
 
   echo "Enabling systemd service."
   sudo systemctl enable autodarts


### PR DESCRIPTION
`addgroup` is for creating groups and takes only one argument (group name) hence the current `addgroup` command responds with
```shell
fatal: addgroup with two arguments is an unspecified operation.
```
To add a user to an _existing_ group, `adduser` is needed which takes the provided arguments.